### PR TITLE
Revert "[ chore ] Update locks"

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1622445595,
-        "narHash": "sha256-m+JRe6Wc5OZ/mKw2bB3+Tl0ZbtyxxxfnAWln8Q5qs+Y=",
+        "lastModified": 1619345332,
+        "narHash": "sha256-qHnQkEp1uklKTpx3MvKtY6xzgcqXDsz5nLilbbuL+3A=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7d706970d94bc5559077eb1a6600afddcd25a7c8",
+        "rev": "2ebf2558e5bf978c7fb8ea927dfaed8fefab2e28",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     "idris2-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1623168186,
-        "narHash": "sha256-ojUCfYziawPb/V2VmoL+JU/WVL05NnKy3Bq3TECUmCw=",
+        "lastModified": 1619598807,
+        "narHash": "sha256-ddl1PNxnpK+x2kMvXSNLU+/MwG4T8IWXy7NQp1DleGo=",
         "owner": "idris-lang",
         "repo": "idris2",
-        "rev": "abd5432885331390cfde74e944091e677dd4b128",
+        "rev": "96a2809f622034e59a956aee89ee2b1a2e4bec1f",
         "type": "github"
       },
       "original": {
@@ -33,11 +33,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1623252537,
-        "narHash": "sha256-/vaWqzMZLWiDHU4owrQLiqUP6ffCgsQjl0vWnBfQIiw=",
+        "lastModified": 1619607457,
+        "narHash": "sha256-FFKMXfeYtJlQc7NHRq2kIa8f906JiQl/Xk3zAvcJv+k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "135ba31fa74c8f40bee9807e076c7b889c094c7c",
+        "rev": "e7e72e070b9a82730e97134bf33d6a7e608a6bf3",
         "type": "github"
       },
       "original": {

--- a/idris2/package.nix
+++ b/idris2/package.nix
@@ -8,7 +8,6 @@
 , gambit
 , nodejs
 , idris2-src
-, gmp
 }:
 
 # Uses scheme to bootstrap the build of idris2
@@ -20,7 +19,7 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
   nativeBuildInputs = [ makeWrapper clang chez ];
-  buildInputs = [ chez gmp ];
+  buildInputs = [ chez ];
 
   prePatch = let match = "$\{GIT_SHA1}"; in
     ''

--- a/packages/pretty-show.toml
+++ b/packages/pretty-show.toml
@@ -4,8 +4,8 @@ version = "0.2.0"
 [ source ]
 owner = "stefan-hoeck"
 repo = "idris2-pretty-show"
-rev = "1c872b6b0dfcb3f2cd73ead773fa267c04780eda"
-sha256 = "2Li9x4HvBUGZEqFlysGafQ06I2kbKyMdz2WiJbnJMZI="
+rev = "28d83af17c7f281cf49e593d4283d1b877788231"
+sha256 = "gOLFijoE7zJVlbPAlwMLLy/fYTE4++CQAQjsfd9EisY="
 
 [ depends ]
 idrisLibs = [ "elab-util", "sop" ]

--- a/packages/sop.toml
+++ b/packages/sop.toml
@@ -4,8 +4,8 @@ version = "0.3.0"
 [ source ]
 owner = "stefan-hoeck"
 repo = "idris2-sop"
-rev = "c1117fc24256d188fbd1503512e18c0eb5aae083"
-sha256 = "3QlRX7udc9r6atPIc9GqYD5Lj7jTfeOIQpUzB/sr+/k="
+rev = "c6ca335f7bd26c3c9c53ad0b34910a5a3152f058"
+sha256 = "lD7XBlVGTTrUYuW2i2In1xkE1PAxKC9NnR3+2by1zAU="
 
 [ depends ]
 idrisLibs = [ "elab-util" ]


### PR DESCRIPTION
This reverts commit acf8f5b154a3cef42cd159f9798dbb78dc2c56d0.

Idris2 has changed wrapper files produced by chez, breaking our Darwin implementation.

We are stuck with an older version of idris2 while a patch for this gets finalized.