### PR TITLE
Expose buildIdris to consumer flakes

### DIFF
--- a/packages/default.nix
+++ b/packages/default.nix
@@ -26,4 +26,5 @@ let
 in
 {
   inherit extendWithPackages packages buildTOMLSource callNix;
+  buildIdris = utils.buildIdris;
 }

--- a/utils/default.nix
+++ b/utils/default.nix
@@ -16,6 +16,7 @@ let
 
 in
 {
+  inherit buildIdris;
   builders = ipkgs:
     {
       inherit (buildFromTOML ipkgs)


### PR DESCRIPTION
I want to directly call `buildIdris` from nix, this pr exposes it.