### PR TITLE
Add Idris2-dom support

### DIFF
--- a/packages/default.nix
+++ b/packages/default.nix
@@ -18,6 +18,10 @@ let
 
     hedgehog = callTOML ./hedgehog.toml;
 
+    experimental = callTOML ./experimental.toml;
+
+    dom = callTOML ./dom.toml;
+
     idrall = callTOML ./idrall.toml;
 
     lsp = extendWithPackages (callTOML ./lsp.toml);

--- a/packages/dom.toml
+++ b/packages/dom.toml
@@ -8,4 +8,4 @@ rev = "v0.1.0"
 sha256 = "sha256-bHy+bcq92WeNdHlfzrZyu6PfX0Zd9y2qURFk0G+OXS0="
 
 [ depends ]
-idrisLibs = [ "sop" "experimental" ]
+idrisLibs = [ "sop", "experimental" ]

--- a/packages/dom.toml
+++ b/packages/dom.toml
@@ -1,0 +1,11 @@
+name = "dom"
+version = "0.1.0"
+
+[ source ]
+owner = "stefan-hoeck"
+repo = "idris2-dom"
+rev = "v0.1.0"
+sha256 = "sha256-bHy+bcq92WeNdHlfzrZyu6PfX0Zd9y2qURFk0G+OXS0="
+
+[ depends ]
+idrisLibs = [ "sop" "experimental" ]

--- a/packages/experimental.toml
+++ b/packages/experimental.toml
@@ -1,0 +1,8 @@
+name = "experimental"
+version = "0.2.0"
+
+[ source ]
+owner = "stefan-hoeck"
+repo = "idris2-experimental"
+rev = "2e4b2699bd1baa18a4a11883ff9e2d5fb6dafad8"
+sha256 = "sha256-52OeqhXsEwWezTj8lDgS6xiNsuEeJQUhzGLSp86+6Js="


### PR DESCRIPTION
Resolves #7

This doesn't build right now... For some reason, the `dom` package doesn't recognize the `experimental` package from the overlay. Any ideas why?

Full error:

```
[nix-shell:~/projects/idris2-pkgs]$ nix build .#dom
warning: Git tree '/home/demo/projects/idris2-pkgs' is dirty
error: while parsing a TOML string: Unidentified trailing character 'e'---did you forget a '#'? at line 11

       at /nix/store/dlxdlxsjxks96fqwbn8il2rrs93j20ma-source/utils/callToml.nix:5:20:

            4|   # loadTOML : File -> TomlDec
            5|   loadTOML = file: builtins.fromTOML (builtins.readFile file);
             |                    ^
            6|
(use '--show-trace' to show detailed location information)
```

I have noticed that this strange error message means that the package does not exist. 

Thoughts? What am I doing wrong?